### PR TITLE
Add a version number for pypi package

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,6 +2,7 @@ import setuptools
 
 setuptools.setup(
     name='pypi-slug',
+    version='0.1.0',
     install_requires=open('requirements.txt').read().splitlines(),
     packages=setuptools.find_packages()
 )


### PR DESCRIPTION
If you use a tool, like pip-review to manage package update in your project, the tool always tells you to update to version **2020.7.1** and you are actual version is **0.0.0**. But version **2020.7.1** doesn't really exist on pypi, so you only get version **0.0.0** due to no version number in setup.py. To avoid this, a version number in setup.py will fix this behavior.